### PR TITLE
fix(model): Change user_id to user_auth_id in roleModel

### DIFF
--- a/server/models/roleModel.ts
+++ b/server/models/roleModel.ts
@@ -6,7 +6,7 @@ const getUserRoles = async (userId: string) => {
       SELECT r.role_name 
       FROM roles r
       JOIN user_to_role utr ON r.id = utr.role_id
-      WHERE utr.user_id = $1
+      WHERE utr.user_auth_id = $1
     `;
     const values = [userId];
     const result = await pool().query(query, values);


### PR DESCRIPTION
## Summary
Updated roleModel.ts to use `user_auth_id` instead of `user_id` in the user role query to align with the correct database column reference.

## Related Issue

## Changes Made
- Modified SQL query in roleModel.ts to use `user_auth_id` column in the WHERE clause instead of `user_id`
- Updated the JOIN condition to match against `utr.user_auth_id = $1` for proper user role retrieval

## Database Changes (if applicable)
- **Before**: Query referenced `user_id` column which may not exist or be the correct foreign key
- **After**: Query now correctly references `user_auth_id` column in the user_to_role table

## How to Test
1. Call any endpoint that retrieves user roles
2. Verify that roles are returned correctly for authenticated users
3. Confirm no database errors occur during role queries

## Checklist
- [x] Code runs and builds without errors
- [x] Functionality works according to the related UCD main/alt paths
- [x] Database column reference is correct
- [x] Manual testing done and steps documented under **How to Test**