### PR TITLE
fix(session): Update end_date_utc format in simulation middleware

### DIFF
--- a/server/controllers/authController.ts
+++ b/server/controllers/authController.ts
@@ -22,6 +22,8 @@ const isAuthenticated = (req: Request, res: Response, next: NextFunction): void 
         req.session.email = decoded.email;
         req.session.role = decoded.role;
         req.session.save();
+
+        // console.log('My date from cookie', req.session.end_date_utc);
       }
       res.status(200).json({
         isAuthenticated: true,

--- a/server/controllers/employeeController.ts
+++ b/server/controllers/employeeController.ts
@@ -33,6 +33,8 @@ const loginEmployee = async (req: Request, res: Response, next: NextFunction) =>
       req.session.email = res.locals.email;
       req.session.role = res.locals.role;
 
+      // console.log('My Date: ', req.session.end_date_utc);
+
       const userPayload = {
         user_id: res.locals.user_id,
         username: res.locals.username,

--- a/server/middlewares/simulationMiddleware.ts
+++ b/server/middlewares/simulationMiddleware.ts
@@ -38,7 +38,8 @@ const simulationMiddleware = async (req: Request, res: Response, next: NextFunct
         return;
       }
     } else if (req.session.end_date_is_default) {
-      req.session.end_date_utc = new Date().toISOString();
+      req.session.end_date_utc = new Date().toUTCString();
+      // console.log('Updated Date:', req.session.end_date_utc);
     }
 
     next();


### PR DESCRIPTION
<!-- BOT_SUMMARY_START -->
 ## Summary
This PR aims to update the format of the `end_date_utc` in the simulation middleware, addressing the issue reported in the title. This update is expected to ensure the correct date and time representation within the middleware, improving its functionality and overall performance.

## Related Issue
- [Here should be the link to the related Jira ticket]
- [Here should be the link to the User-Centered Design (UCD) of this feature]

## Changes Made
- Update the format of `end_date_utc` in the simulation middleware (SHA: 3379aab)

## Screenshots / UI Changes (if any)
Since this PR primarily focuses on updating the backend middleware, there are no UI changes in this PR.

## Database Changes (if applicable)
- Information on database changes is not applicable as this PR does not involve any database modifications.

## How to Test
1. Initialize a new simulation session with a valid end date.
2. Verify that the `end_date_utc` is correctly represented and updated in the simulation middleware.

## Checklist
- [ ] Code runs and builds without errors
- [ ] Functionality works according to the related UCD main/alt paths (Not applicable as this PR does not affect the UI.)
- [ ] UCD pre database condition and post database condition are clearly stated in the PR (Not applicable as this PR does not involve any database modifications.)
- [ ] Naming conventions followed:
    - [ ] React component and file names are in PascalCase
    - [ ] API route URLs use kebab-case (e.g., `/get-user-profile`) (Not applicable as this PR does not involve any frontend changes.)
    - [ ] JSON keys use camelCase
- [ ] Git commit messages are clear and follow present-tense format (e.g., "Add login validation") (Completed)
- [ ] Manual testing done and steps documented under **How to Test** (Completed)
- [ ] Screenshots or recordings added if UI is affected (Not applicable as this PR does not affect the UI.)
<!-- BOT_SUMMARY_END -->