### PR TITLE
minor ui fix and changes

### DIFF
--- a/client/src/pages/sale-transaction/CartItemsWithPayment.jsx
+++ b/client/src/pages/sale-transaction/CartItemsWithPayment.jsx
@@ -380,7 +380,7 @@ const CartItemsWithPayment = ({
                 methodId: 10,
                 methodName: `GST (${gstRate}%)`,
                 amount: newGSTAmount,
-                remark: `Dynamic GST at ${gstRate}%`,
+                remark: ` GST rate ${gstRate}%`,
                 isGST: true
               };
               
@@ -489,7 +489,7 @@ const CartItemsWithPayment = ({
         methodId: 10,
         methodName: `GST (${gstRate}%)`,
         amount: roundTo2Decimals(gstAmount),
-        remark: isDynamicGST ? `Dynamic GST at ${gstRate}%` : `Auto-calculated GST at ${gstRate}%`,
+        remark: isDynamicGST ? `GST rate ${gstRate}%` : `Auto-GST rate ${gstRate}%`,
         isGST: true
       };
       
@@ -581,7 +581,7 @@ const CartItemsWithPayment = ({
             methodId: 10,
             methodName: `GST (${gstRate}%)`,
             amount: newGSTAmount,
-            remark: `Dynamic GST at ${gstRate}%`,
+            remark: ` GST rate ${gstRate}%`,
             isGST: true
           };
           

--- a/client/src/pages/sale-transaction/ProcessPaymentSaleTransaction.jsx
+++ b/client/src/pages/sale-transaction/ProcessPaymentSaleTransaction.jsx
@@ -186,7 +186,7 @@ const ProcessPaymentSaleTransaction = () => {
                 methodId: '10',
                 methodName: `GST (${gstRate}%)`,
                 amount: newGSTAmount,
-                remark: `Dynamic GST at ${gstRate}%`,
+                remark: ` GST rate ${gstRate}%`,
                 isGST: true
             };
 


### PR DESCRIPTION
This pull request updates the wording of GST-related remarks in the `CartItemsWithPayment` and `ProcessPaymentSaleTransaction` components to simplify and standardize the phrasing. The changes replace "Dynamic GST" and "Auto-calculated GST" with more concise descriptions like "GST rate" and "Auto-GST rate."

### Updates to GST-related remarks:

* [`client/src/pages/sale-transaction/CartItemsWithPayment.jsx`](diffhunk://#diff-e061d0ac138b7995e5435d6781c06cf3323f7c24cb3799b4683264764371e77bL383-R383): Updated the `remark` field in multiple instances to use simplified phrasing, replacing "Dynamic GST at ${gstRate}%" with "GST rate ${gstRate}%" and "Auto-calculated GST at ${gstRate}%" with "Auto-GST rate ${gstRate}%." [[1]](diffhunk://#diff-e061d0ac138b7995e5435d6781c06cf3323f7c24cb3799b4683264764371e77bL383-R383) [[2]](diffhunk://#diff-e061d0ac138b7995e5435d6781c06cf3323f7c24cb3799b4683264764371e77bL492-R492) [[3]](diffhunk://#diff-e061d0ac138b7995e5435d6781c06cf3323f7c24cb3799b4683264764371e77bL584-R584)

* [`client/src/pages/sale-transaction/ProcessPaymentSaleTransaction.jsx`](diffhunk://#diff-9f27eb21ee7d8434de77a454a4aee49f82d8d8da1b506285ccd7b24008267322L189-R189): Standardized the `remark` field by replacing "Dynamic GST at ${gstRate}%" with "GST rate ${gstRate}%."

<!-- BOT_SUMMARY_START -->
 ## Summary
This Pull Request simplifies and standardizes the phrasing of GST-related remarks in the `CartItemsWithPayment` and `ProcessPaymentSaleTransaction` components. The changes replace "Dynamic GST" and "Auto-calculated GST" with more concise descriptions like "GST rate" and "Auto-GST rate." The overall goal of these changes is to improve the readability and consistency of the user interface.

## Related Issue
- Jira Ticket: <Insert related Jira ticket number here>
- UCD of this feature: <Insert UCD link here>

## Changes Made
- Updated the `remark` field in multiple instances of `CartItemsWithPayment.jsx` to use simplified phrasing. Replaced "Dynamic GST at ${gstRate}%" with "GST rate ${gstRate}%" and "Auto-calculated GST at ${gstRate}%" with "Auto-GST rate ${gstRate}%." (SHA: 26448c6)
- Standardized the `remark` field in `ProcessPaymentSaleTransaction.jsx` by replacing "Dynamic GST at ${gstRate}%" with "GST rate ${gstRate}%." (SHA: <Insert related SHA here>)

## Screenshots / UI Changes (if any)
Unfortunately, there are no significant UI changes to show in this Pull Request.

## Database Changes (if applicable)
[This PR does not involve any database changes]

## How to Test
1. Open the application and navigate to the sale transaction page.
2. Observe the GST-related remarks in the `CartItemsWithPayment` and `ProcessPaymentSaleTransaction` components. The wording should now be simplified and standardized.

## Checklist
- [ ] Code runs and builds without errors
- [ ] Functionality works according to the related UCD main/alt paths
- [ ] UCD pre database condition and post database condition are clearly stated in the PR (if applicable)
- [ ] Naming conventions followed:
    - [ ] React component and file names are in PascalCase
    - [ ] API route URLs use kebab-case (e.g., `/get-user-profile`)
    - [ ] JSON keys use camelCase
- [ ] Git commit messages are clear and follow present-tense format (e.g., "Update GST phrasing")
- [ ] Manual testing done and steps documented under **How to Test**
- [ ] Screenshots or recordings added if UI is affected [Not Applicable in this case]
<!-- BOT_SUMMARY_END -->